### PR TITLE
fix: resolve cross-doc inconsistencies (#3-#8)

### DIFF
--- a/PASSPACK_SPEC.md
+++ b/PASSPACK_SPEC.md
@@ -148,7 +148,7 @@ Unnumbered `{{answer}}` is equivalent to `{{c1::answer}}`.
 
 ```json
 {
-  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "uuid": "1e9de75e-e39b-4857-9481-8baa708dc15a",
   "schemaVersion": "passpack-v1",
   "text": "I'm gonna grab a bite."
 }
@@ -169,7 +169,7 @@ The `media` object references files bundled in the card pack.
 | `visual` | string | ❌ | Path to video (.mp4) or image (.jpg/.png) |
 | `audio` | string | ❌ | Path to standalone audio file (.m4a) |
 
-All paths are relative to the card pack root. A card with `"visual": "media/a1b2c3d4.mp4"` maps to the file `media/a1b2c3d4.mp4` inside the ZIP archive.
+All paths are relative to the card pack root. A card with `"visual": "media/1e9de75e.mp4"` maps to the file `media/1e9de75e.mp4` inside the ZIP archive.
 
 ### 3.2 Media Format Requirements
 
@@ -189,8 +189,8 @@ All paths are relative to the card pack root. A card with `"visual": "media/a1b2
 
 ```json
 "media": {
-  "visual": "media/a1b2c3d4.mp4",
-  "audio": "media/a1b2c3d4.m4a"
+  "visual": "media/1e9de75e.mp4",
+  "audio": "media/1e9de75e.m4a"
 }
 ```
 
@@ -352,8 +352,8 @@ A `.passpack` file is a ZIP archive.
 unit_01_greetings.passpack
 ├── manifest.json
 └── media/
-    ├── a1b2c3d4.mp4
-    ├── a1b2c3d4.m4a
+    ├── 1e9de75e.mp4
+    ├── 1e9de75e.m4a
     ├── b2c3d4e5.jpg
     └── ...
 ```
@@ -399,13 +399,13 @@ The `manifest.json` file describes the pack and contains all cards.
   "cardCount": 1,
   "cards": [
     {
-      "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "uuid": "1e9de75e-e39b-4857-9481-8baa708dc15a",
       "schemaVersion": "passpack-v1",
       "text": "I'm gonna grab a bite.",
       "cardType": "sentence",
       "source": "The Middle S01E03",
       "media": {
-        "visual": "media/a1b2c3d4.mp4"
+        "visual": "media/1e9de75e.mp4"
       },
       "analysis": [
         {
@@ -518,7 +518,7 @@ Current: `passpack-v1`
 | Scope | Convention | Example |
 |-------|------------|---------|
 | JSON fields | camelCase | `sourceLang`, `cardType` |
-| Media file names | UUID-based (recommended, not required) | `a1b2c3d4.mp4` |
+| Media file names | UUID-based (recommended, not required) | `1e9de75e.mp4` |
 | Enum values | lowercase | `sentence`, `known`, `ai+human` |
 | Deck separator | `/` | `IELTS/Listening/Part 1` |
 | Custom fields | `x_` prefix | `x_myapp_score` |
@@ -562,7 +562,7 @@ A conforming reader MUST:
 
 A conforming writer MUST:
 - Produce valid UTF-8 JSON
-- Include all required fields in every card
+- Include all required fields in every card (`schemaVersion` MAY be omitted from cards inside a manifest that declares it at pack level)
 - Ensure `manifest.cardCount` equals `cards.length`
 - Ensure all media paths in cards reference files that exist in the archive
 - Use UUID v4 for card identifiers
@@ -682,7 +682,7 @@ For vocabulary cards.
 
 ```json
 {
-  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "uuid": "1e9de75e-e39b-4857-9481-8baa708dc15a",
   "schemaVersion": "passpack-v1",
   "text": "I'm gonna grab a bite.",
   "cardType": "sentence",
@@ -690,8 +690,8 @@ For vocabulary cards.
   "targetLang": "zh-CN",
   "source": "The Middle S01E03",
   "media": {
-    "visual": "media/a1b2c3d4.mp4",
-    "audio": "media/a1b2c3d4.m4a"
+    "visual": "media/1e9de75e.mp4",
+    "audio": "media/1e9de75e.m4a"
   },
   "analysis": [
     {

--- a/PASSPACK_SPEC.zh-CN.md
+++ b/PASSPACK_SPEC.zh-CN.md
@@ -43,7 +43,7 @@ PassPack 是一个**开放的语言学习卡片标准**。它定义了卡片、�
 
 | 字段 | 说明 | 举例 |
 |------|------|------|
-| `uuid` | 全球唯一 ID | `a1b2c3d4-e5f6-...` |
+| `uuid` | 全球唯一 ID (UUID v4) | `1e9de75e-e39b-...` |
 | `schemaVersion` | 格式版本 | `passpack-v1` |
 | `text` | 原文内容（一个词、一句话、一段对话都行） | `I'm gonna grab a bite.` |
 
@@ -70,7 +70,7 @@ PassPack 是一个**开放的语言学习卡片标准**。它定义了卡片、�
 
 ```json
 {
-  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "uuid": "1e9de75e-e39b-4857-9481-8baa708dc15a",
   "schemaVersion": "passpack-v1",
   "text": "I'm gonna grab a bite."
 }
@@ -144,7 +144,7 @@ formality、bestFor、avoidWith、grammar、commonMistakes、culturalNote 等字
 
 pronunciation、partOfSpeech、definitions 等字段。
 
-**社区可以注册新的分析类型**，用 `x-` 前缀避免冲突。App 遇到不认识的类型直接跳过。
+**社区可以注册新的分析类型**，用 `x_` 前缀避免冲突（与自定义字段统一）。App 遇到不认识的类型直接跳过。
 
 ---
 
@@ -176,12 +176,12 @@ pronunciation、partOfSpeech、definitions 等字段。
 
 ```json
 [
-  { "date": "2026-01-15", "rating": 3 },
-  { "date": "2026-01-22", "rating": 4 }
+  { "date": "2026-01-15T08:30:00Z", "rating": 3 },
+  { "date": "2026-01-22T19:15:00Z", "rating": 4 }
 ]
 ```
 
-评分 1-4：1=完全忘了，2=想了很久，3=想了一下，4=秒回忆。这是 Anki/FSRS 的事实标准。
+`date` 必须是 ISO 8601 UTC 时间。评分 1-4：1=完全忘了，2=想了很久，3=想了一下，4=秒回忆。这是 Anki/FSRS 的事实标准。
 
 新 App 拿到完整日志，可以用自己的算法重跑一遍，几乎完美还原。
 
@@ -195,7 +195,7 @@ ZIP 压缩包：
 unit_01.passpack
 ├── manifest.json
 └── media/
-    ├── a1b2c3d4.mp4
+    ├── 1e9de75e.mp4
     └── ...
 ```
 
@@ -237,9 +237,9 @@ unit_01.passpack
 | 规则 | 说明 |
 |------|------|
 | 自定义字段 | `x_` 开头，其他 App 忽略 |
-| 自定义分析类型 | `x-` 开头 |
+| 自定义分析类型 | `x_` 开头 |
 | 不认识的字段 | 忽略，不报错（像浏览器对待未知 HTML 标签一样） |
-| 不认识的版本号 | 报错，提示用户升级 |
+| 不认识的 `schemaVersion` 大版本号 | 报错，提示用户升级 |
 
 **宽容读取，严格写入。**
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A minimal PassPack card:
 
 ```json
 {
-  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "uuid": "1e9de75e-e39b-4857-9481-8baa708dc15a",
   "schemaVersion": "passpack-v1",
   "text": "I'm gonna grab a bite."
 }
@@ -51,7 +51,7 @@ A rich card with media and AI analysis:
 
 ```json
 {
-  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "uuid": "1e9de75e-e39b-4857-9481-8baa708dc15a",
   "schemaVersion": "passpack-v1",
   "text": "I'm gonna grab a bite.",
   "cardType": "sentence",
@@ -59,7 +59,7 @@ A rich card with media and AI analysis:
   "targetLang": "zh-CN",
   "source": "The Middle S01E03",
   "media": {
-    "visual": "a1b2c3d4.mp4"
+    "visual": "media/1e9de75e.mp4"
   },
   "analysis": [
     {
@@ -90,7 +90,7 @@ A `.passpack` file is a ZIP archive:
 unit_01.passpack
 ├── manifest.json
 └── media/
-    ├── a1b2c3d4.mp4
+    ├── 1e9de75e.mp4
     └── ...
 ```
 


### PR DESCRIPTION
Closes #3, closes #4, closes #5, closes #6, closes #7, closes #8

## Changes

| Issue | Fix |
|-------|-----|
| #3 schemaVersion conformance | Clarified writer conformance: schemaVersion MAY be omitted from cards inside a manifest |
| #4 Non-v4 UUID | Replaced `a1b2c3d4-e5f6-7890-...` with valid UUID v4 `1e9de75e-e39b-4857-...` across all 3 docs |
| #5 zh-CN analysis prefix | `x-` → `x_` in zh-CN (aligned with English §8.2 and §10) |
| #6 zh-CN reviewLog date | Date-only → ISO 8601 UTC datetime (aligned with English §5.2) |
| #7 README media path | Added `media/` prefix to match spec §3 convention |
| #8 zh-CN version rule | Clarified as major version rejection (aligned with English §8.3) |