### PR TITLE
fix: clarify reader conformance for schemaVersion inheritance (#10)

### DIFF
--- a/PASSPACK_SPEC.md
+++ b/PASSPACK_SPEC.md
@@ -552,7 +552,7 @@ Pack authors MAY choose any license by setting `manifest.license`.
 
 A conforming reader MUST:
 - Parse `manifest.json` as UTF-8 JSON
-- Accept any card with the three required fields (`uuid`, `schemaVersion`, `text`)
+- Accept any card with `uuid` and `text`; `schemaVersion` is also required for standalone cards, but MAY be inherited from the manifest when cards are inside a pack
 - Ignore unknown fields silently
 - Ignore unknown analysis types silently
 - Reject unknown `schemaVersion` major versions with a clear error


### PR DESCRIPTION
Closes #10

§12.1 Reader Conformance now explicitly states that card-level `schemaVersion` MAY be inherited from the manifest when cards are inside a pack. This resolves the conflict between §2.1 (optional inside manifest), §12.1 (previously implied always required), and §12.2 (allows omission).